### PR TITLE
Further updates for hepdata-converter on python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@
 services:
   - docker
 
-language: python
-
-python:
-  - "3.6"
+language: minimal
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Based on ROOT project's conda image which uses python3. Fixed to a digest as their docker images aren't tagged
-FROM rootproject/root-conda@sha256:c99817608cebcfa7041e00006edb3d5f10983674294c03f180b635a19c2a06f5
+# Based on ROOT project's conda image which uses python3.7
+FROM rootproject/root-conda:6.20.00
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ hepdata-validator==0.2.2
 coverage==5.0.3
 coveralls==1.11.1
 pyyaml==5.3
-matplotlib==3.1.3
-six==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 hepdata-validator==0.2.2
-coverage==5.0.3
-coveralls==1.11.1
+coverage==5.1
 pyyaml==5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 hepdata-validator==0.2.2
 coverage==5.0.3
 coveralls==1.11.1
-future==0.18.2
 pyyaml==5.3
 matplotlib==3.1.3
 six==1.14.0


### PR DESCRIPTION
We're removing future from `hepdata-converter`, so it's no longer needed in the docker image. Also removed other unused packages and updated to the latest version of ROOT.