### PR TITLE
ROOT and YODA updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Based on ROOT project's conda image which uses python3.7
-FROM rootproject/root-conda:6.20.00
+FROM rootproject/root:6.22.02-conda
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++
 
-ENV YODA_VERSION 1.8.2
+ENV YODA_VERSION 1.8.3
 
 COPY requirements.txt /tmp/requirements.txt
 
@@ -21,7 +21,7 @@ pkg-config \
 libpng-dev \
 libyaml-dev
 
-RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && ./configure --with-zlib=/opt/conda --prefix=/opt/conda && make -j4 && make -j4 install && cd ../"
+RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && ./configure --disable-root --with-zlib=/opt/conda --prefix=/opt/conda && make -j4 && make -j4 install && cd ../"
 
 RUN conda install git pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-# Based on ROOT project's conda image which uses python3.7
-FROM rootproject/root:6.22.02-conda
-ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
-ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++
+# Based on ROOT project's ubuntu image which uses python3.8
+FROM rootproject/root:6.22.02-ubuntu20.04
 
 ENV YODA_VERSION 1.8.3
 
@@ -15,14 +13,15 @@ cmake \
 binutils \
 libboost-all-dev \
 wget \
+python3-pip \
 # required by matplotlib
 libfreetype6-dev \
 pkg-config \
 libpng-dev \
 libyaml-dev
 
-RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && ./configure --disable-root --with-zlib=/opt/conda --prefix=/opt/conda && make -j4 && make -j4 install && cd ../"
+RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && PYTHON=/usr/bin/python3 ./configure --disable-root && make -j4 && make -j4 install && cd ../"
 
-RUN conda install git pip
+RUN pip3 install -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
-RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+ENV LD_LIBRARY_PATH /usr/local/lib


### PR DESCRIPTION
Updated to ROOT 6.22.02 and YODA 1.8.3.

Switched to using ubuntu as the base image now ROOT have an ubuntu 20.04 image using python 3.8.

Tested using the [feature/root-yoda-updates](https://github.com/HEPData/hepdata-converter/tree/feature/root-yoda-updates) branch of hepdata-converter:

```bash
cd hepdata-converter-docker
docker build . -t hepdata-converter
cd ../hepdata-converter
export DOCKER_IMAGE=hepdata-converter
./run-tests.sh
```

Partial fix for #7 