### PR TITLE
Add HDF5 to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ python3-setuptools \
 libfreetype6-dev \
 pkg-config \
 libpng-dev \
-libyaml-dev
+libyaml-dev \
+# required by YODA-HDF5
+libhdf5-dev
 
 RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && PYTHON=/usr/bin/python3 ./configure --disable-root && make -j4 && make -j4 install && cd ../"
 


### PR DESCRIPTION
Hi @GraemeWatt,

You were exactly right, all that needs to be done to be able to use HDF5 with YODA in the docker container is to add `libhdf5-dev` to the installation. Thanks for tip! This PR does just that.