### PR TITLE
update format to key=value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Based on ROOT project's Ubuntu image which uses Python 3.12
 FROM rootproject/root:6.32.04-ubuntu24.04
 
-ENV YODA_VERSION 2.1.0
+ENV YODA_VERSION=2.1.0
 
 RUN apt-get -y update && apt-get install -y \
 git \
@@ -23,5 +23,5 @@ RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.
 
 RUN pip config set global.break-system-packages true
 
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PYTHONPATH $PYTHONPATH:/usr/local/lib/python3.12/site-packages
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.12/site-packages


### PR DESCRIPTION
Hi @GraemeWatt,

While I'm at it: docker currently complains that the format `ENV key value` used in the docker file is deprecated and `ENV key=value` should be used:
```
$ sudo docker build . --file Dockerfile --tag hepdata-converter
[+] Building 0.4s (8/8) FINISHED                                                        docker:default
 => [internal] load build definition from Dockerfile                                              0.0s
 => => transferring dockerfile: 870B                                                              0.0s
 => [internal] load metadata for docker.io/rootproject/root:6.32.04-ubuntu24.04                   0.3s
 => [internal] load .dockerignore                                                                 0.0s
 => => transferring context: 2B                                                                   0.0s
 => [1/4] FROM docker.io/rootproject/root:6.32.04-ubuntu24.04@sha256:d9e40e760d31416265b9caa0b87  0.0s
 => CACHED [2/4] RUN apt-get -y update && apt-get install -y git dpkg-dev make cmake binutils li  0.0s
 => CACHED [3/4] RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-2.1.0.tar.gz   0.0s
 => CACHED [4/4] RUN pip config set global.break-system-packages true                             0.0s
 => exporting to image                                                                            0.0s
 => => exporting layers                                                                           0.0s
 => => writing image sha256:0a7bb95a78f68a585782d36d5e91698301737e54c531adcb6efbf2f1a65092a1      0.0s
 => => naming to docker.io/library/hepdata-converter_key-value                                    0.0s

 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 27)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
n
```

This PR fixes that, so now the output is
```
$ sudo docker build . --file Dockerfile --tag hepdata-converter
[+] Building 0.4s (8/8) FINISHED                                                        docker:default
 => [internal] load build definition from Dockerfile                                              0.0s
 => => transferring dockerfile: 870B                                                              0.0s
 => [internal] load metadata for docker.io/rootproject/root:6.32.04-ubuntu24.04                   0.3s
 => [internal] load .dockerignore                                                                 0.0s
 => => transferring context: 2B                                                                   0.0s
 => [1/4] FROM docker.io/rootproject/root:6.32.04-ubuntu24.04@sha256:d9e40e760d31416265b9caa0b87  0.0s
 => CACHED [2/4] RUN apt-get -y update && apt-get install -y git dpkg-dev make cmake binutils li  0.0s
 => CACHED [3/4] RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-2.1.0.tar.gz   0.0s
 => CACHED [4/4] RUN pip config set global.break-system-packages true                             0.0s
 => exporting to image                                                                            0.0s
 => => exporting layers                                                                           0.0s
 => => writing image sha256:0a7bb95a78f68a585782d36d5e91698301737e54c531adcb6efbf2f1a65092a1      0.0s
 => => naming to docker.io/library/hepdata-converter_key-value                                    0.0s
```