### PR TITLE
Fix docker container for YODA-H5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ pkg-config \
 libpng-dev \
 libyaml-dev \
 # required by YODA-HDF5
-libhdf5-dev
+libhdf5-dev \
+cython3
 
-RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && PYTHON=/usr/bin/python3 ./configure --disable-root && make -j4 && make -j4 install && cd ../"
+RUN /bin/bash -c "source /root/.bashrc && cd /tmp && wget -O YODA-$YODA_VERSION.tar.gz https://yoda.hepforge.org/downloads/?f=YODA-$YODA_VERSION.tar.gz && tar -xzf YODA-$YODA_VERSION.tar.gz && cd YODA-$YODA_VERSION && PYTHON=/usr/bin/python3 ./configure && make -j4 && make -j4 install && cd ../"
 
 RUN pip config set global.break-system-packages true
 


### PR DESCRIPTION
Hi @GraemeWatt,

Finally managed to track down why the yoda-H5 writing was failing: the python extensions weren't properly installed because cython was missing. This PR fixes that.

While at it, this PR also removes the `--disable-root` flag from the YODA configuration. It's apparently not supported any more because it throws
```
 configure: WARNING: unrecognized options: --disable-root
```